### PR TITLE
Rewrite velocity calculation

### DIFF
--- a/safety_shield/include/safety_shield/robot_reach.h
+++ b/safety_shield/include/safety_shield/robot_reach.h
@@ -202,12 +202,14 @@ class RobotReach {
   void calculateAllTransformationMatricesAndCapsules(const std::vector<double>& q);
 
   /**
-   * @brief returns joint jacobian
+   * @brief Returns Jacobian of a point attached to the i-th joint.
+   * @details You often take robot_capsules_for_velocity_[joint].p1_ or robot_capsules_for_velocity_[joint].p2_ as point.
    * @assumption calculateAlltransformationMatricesAndCapsules() was called before
-   * @param joint jacobian for which joint
-   * @return jacobian
+   * @param joint Jacobian for which joint
+   * @param point Jacobian for which point
+   * @return Jacobian 6 x nb_joints
    */
-  Eigen::Matrix<double, 6, Eigen::Dynamic> getJacobian(const int joint);
+  Eigen::Matrix<double, 6, Eigen::Dynamic> getJacobian(const int joint, const reach_lib::Point& point);
 
   /**
    * @brief computes approximate maximum cartesian velocity of a specific capsule

--- a/safety_shield/include/safety_shield/robot_reach.h
+++ b/safety_shield/include/safety_shield/robot_reach.h
@@ -38,6 +38,16 @@ class RobotReach {
     EXACT,
   };
 
+  /**
+   * @brief Velocity in SE3, where the first element is the linear velocity and the second the angular velocity
+   */
+  typedef std::pair<Eigen::Vector3d, Eigen::Vector3d> SE3Vel;
+
+  /**
+   * @brief Veloctiy in SE3 of the two points that define a capsule
+   */
+  typedef std::pair<SE3Vel, SE3Vel> CapsuleVelocity;
+
  private:
   /**
    * @brief the number of joints of the robot
@@ -187,16 +197,34 @@ class RobotReach {
   double maxVelocityOfMotion(const Motion& motion);
 
   /**
-   * @brief calculates maximum cartesian velocity for a specific capsule
+   * @brief Calculate the cartesian velocity of both defining point of a specific capsule
+   * @assumption calculateAlltransformationMatricesAndCapsules() was called before
+   * @param capsule which capsule
+   * @param q_dot velocity configuration of robot
+   * @return Velocity in SE3 of both Capusle points
+   */
+  CapsuleVelocity getVelocityOfCapsule(const int capsule, std::vector<double> q_dot);
+
+  /**
+   * @brief Get the maximum Cartesian velocity of a specific capsule point
+   * 
+   * @param capsule 
+   * @param velocity velocity in SE3 of capsule point
+   * @return double maximum cartesian velocity of capsule point
+   */
+  double getMaxCartVelocityOfCapsulePoint(const int capsule, const SE3Vel& velocity);
+
+  /**
+   * @brief Calculate the maximum norm of the cartesian velocity for a specific capsule
+   * @assumption calculateAlltransformationMatricesAndCapsules() was called before
    * @param capsule which capsule
    * @param q_dot velocity configuration of robot
    * @return maximum cartesian velocity of capsule
    */
-  double velocityOfCapsule(const int capsule, std::vector<double> q_dot);
+  double getMaxVelocityOfCapsule(const int capsule, std::vector<double> q_dot);
 
   /**
    * @brief calculates all transformation matrices and capsules for a specific robot configuration and sets them
-   * @assumption velocityOfMotion was called before
    * @param q vector of robot angles
    */
   void calculateAllTransformationMatricesAndCapsules(const std::vector<double>& q);

--- a/safety_shield/src/robot_reach.cc
+++ b/safety_shield/src/robot_reach.cc
@@ -124,7 +124,7 @@ void RobotReach::calculateAllTransformationMatricesAndCapsules(const std::vector
 
 double RobotReach::velocityOfCapsule(const int capsule, std::vector<double> q_dot) {
   double epsilon = 1e-6;
-  Eigen::Matrix<double, 6, Eigen::Dynamic> jacobian = getJacobian(capsule);
+  Eigen::Matrix<double, 6, Eigen::Dynamic> jacobian = getJacobian(capsule, robot_capsules_for_velocity_[capsule].p2_);
   Eigen::VectorXd velocity = Eigen::Map<Eigen::VectorXd, Eigen::Unaligned>(q_dot.data(), q_dot.size());
   Eigen::Vector<double, 6> result = jacobian * velocity.segment(0, capsule + 1);
   Eigen::Vector3d v = result.segment(0, 3);
@@ -143,10 +143,10 @@ double RobotReach::velocityOfCapsule(const int capsule, std::vector<double> q_do
   }
 }
 
-Eigen::Matrix<double, 6, Eigen::Dynamic> RobotReach::getJacobian(const int joint) {
+Eigen::Matrix<double, 6, Eigen::Dynamic> RobotReach::getJacobian(const int joint, const reach_lib::Point& point) {
   Eigen::Matrix<double, 6, Eigen::Dynamic> jacobian;
   jacobian.setZero(6, joint + 1);
-  Eigen::Vector3d p_e = pointTo3dVector(robot_capsules_for_velocity_[joint].p2_);
+  Eigen::Vector3d p_e = pointTo3dVector(point);
   for (int i = 0; i < joint + 1; ++i) {
     Eigen::Vector3d z_i = z_vectors_[i + 1];
     Eigen::Vector3d p_i = pointTo3dVector(robot_capsules_for_velocity_[i].p1_);

--- a/safety_shield/src/robot_reach.cc
+++ b/safety_shield/src/robot_reach.cc
@@ -101,7 +101,7 @@ double RobotReach::maxVelocityOfMotion(const Motion& motion) {
   calculateAllTransformationMatricesAndCapsules(motion.getAngleRef());
   double max_capsule_vel = 0;
   for (int i = 0; i < nb_joints_; ++i) {
-    double capsule_vel = velocityOfCapsule(i, motion.getVelocityRef());
+    double capsule_vel = getMaxVelocityOfCapsule(i, motion.getVelocityRef());
     max_capsule_vel = std::max(max_capsule_vel, capsule_vel);
   }
   return max_capsule_vel;
@@ -122,23 +122,39 @@ void RobotReach::calculateAllTransformationMatricesAndCapsules(const std::vector
   }
 }
 
-double RobotReach::velocityOfCapsule(const int capsule, std::vector<double> q_dot) {
-  double epsilon = 1e-6;
-  Eigen::Matrix<double, 6, Eigen::Dynamic> jacobian = getJacobian(capsule, robot_capsules_for_velocity_[capsule].p2_);
+RobotReach::CapsuleVelocity RobotReach::getVelocityOfCapsule(const int capsule, std::vector<double> q_dot){
   Eigen::VectorXd velocity = Eigen::Map<Eigen::VectorXd, Eigen::Unaligned>(q_dot.data(), q_dot.size());
-  Eigen::Vector<double, 6> result = jacobian * velocity.segment(0, capsule + 1);
-  Eigen::Vector3d v = result.segment(0, 3);
-  Eigen::Vector3d omega = result.segment(3, 3);
-  if (omega.norm() < epsilon) {
+  // Point 1
+  Eigen::Matrix<double, 6, Eigen::Dynamic> jacobian1 = getJacobian(capsule, robot_capsules_for_velocity_[capsule].p1_);
+  Eigen::Vector<double, 6> result1 = jacobian1 * velocity.segment(0, capsule + 1);
+  RobotReach::SE3Vel vel1(result1.segment(0, 3), result1.segment(3, 3));
+  // Point 2
+  Eigen::Matrix<double, 6, Eigen::Dynamic> jacobian2 = getJacobian(capsule, robot_capsules_for_velocity_[capsule].p2_);
+  Eigen::Vector<double, 6> result2 = jacobian2 * velocity.segment(0, capsule + 1);
+  RobotReach::SE3Vel vel2(result2.segment(0, 3), result2.segment(3, 3));
+  return RobotReach::CapsuleVelocity(vel1, vel2);
+}
+
+double RobotReach::getMaxVelocityOfCapsule(const int capsule, std::vector<double> q_dot) {
+  RobotReach::CapsuleVelocity capsule_velocity = getVelocityOfCapsule(capsule, q_dot);
+  return std::max(
+    getMaxCartVelocityOfCapsulePoint(capsule, capsule_velocity.first),
+    getMaxCartVelocityOfCapsulePoint(capsule, capsule_velocity.second)
+  );
+}
+
+double RobotReach::getMaxCartVelocityOfCapsulePoint(const int capsule, const RobotReach::SE3Vel& velocity) {
+  double epsilon = 1e-6;
+  if (velocity.second.norm() < epsilon) {
     // no angular velocity
-    return v.norm();
+    return velocity.first.norm();
   } else {
     // with angular velocity
     if (velocity_method_ == APPROXIMATE) {
-      return approximateVelOfCapsule(capsule, v, omega);
+      return approximateVelOfCapsule(capsule, velocity.first, velocity.second);
     } else {
       // velocity_method_ == EXACT
-      return exactVelOfCapsule(capsule, v, omega);
+      return exactVelOfCapsule(capsule, velocity.first, velocity.second);
     }
   }
 }


### PR DESCRIPTION
The velocity calculation in robot reach was only based on the second capsule point. 
I added more modularization and included the first capsule point in the calculation.